### PR TITLE
Resultcsv

### DIFF
--- a/losttime/__init__.py
+++ b/losttime/__init__.py
@@ -27,7 +27,7 @@ db = SQLAlchemy(app)
 migrate = Migrate(app, db)
 
 eventfilepath = join('losttime', 'static', 'userfiles')
-eventfiles = UploadSet('eventfiles', ('xml',), lambda app:eventfilepath)
+eventfiles = UploadSet('eventfiles', ('xml', 'csv'), lambda app:eventfilepath)
 entryfilepath = join('losttime', 'static', 'userfiles')
 entryfiles = UploadSet('entryfiles', ('csv',), lambda app:entryfilepath)
 configure_uploads(app, (eventfiles, entryfiles))

--- a/losttime/templates/eventresult/upload.html
+++ b/losttime/templates/eventresult/upload.html
@@ -54,7 +54,7 @@ Dropzone.autoDiscover = false;
 var dzOptions = {
 	url: "{{url_for('eventResult.upload_event')}}",
 	paramName: "eventFile",
-	acceptedFiles: "text/xml",
+	acceptedFiles: "text/xml,.csv",
 	maxFiles: 1,
 	dictMaxFilesExceeded: "You may only upload one results file.",
 	autoProcessQueue: false,

--- a/losttime/views/_orienteer_data.py
+++ b/losttime/views/_orienteer_data.py
@@ -11,7 +11,7 @@
 # www.ercjns.com
 # 2016
 
-import csv
+import csv, unicodedata
 from bs4 import BeautifulSoup as BS
 
 
@@ -406,7 +406,8 @@ class OrienteerResultReader(object):
         except:
             return self.__CSVgetEventClassShortName(line)
     def __CSVgetPersonResultName(self, line):
-        return str(line[self.csvcols['name']].strip('\"\'\/\\ '))
+        name = unicode(line[self.csvcols['name']].strip('\"\'\/\\ '), 'utf-8')
+        return unicodedata.normalize('NFKD', name).encode('ascii', 'ignore')
     def __CSVgetPersonResultClubShort(self, line):
         try:
             return line[self.csvcols['club']].strip('\"\'\/\\ ')

--- a/losttime/views/_orienteer_data.py
+++ b/losttime/views/_orienteer_data.py
@@ -430,6 +430,7 @@ class OrienteerResultReader(object):
             time = mins*60 + secs
             return time, 'ok', 'ok'
         else:
+            timestr = str(timestr[0])
             if timestr in ['dnf', 'mp', 'msp']:
                 return None, timestr, 'ok'
             elif timestr in ['dns', 'dsq', 'nc']:


### PR DESCRIPTION
Allow event results to be uploaded as a csv file in addition to the standard IOF xml files.

`OrienteerXMLReader` is now `OrienteerResultReader `and parses with the expected helper functions based on file extension.

Still considering this as beta functionality, so no documentation or changes to text on the upload page yet.
