### PR TITLE
Refactor output templates

### DIFF
--- a/losttime/views/_output_template_coc.py
+++ b/losttime/views/_output_template_coc.py
@@ -143,3 +143,6 @@ class EventHtmlWriter_COC(EventHtmlWriter):
                 dt("<time>*")
                 dd("the star indicates course completion status was not reported and may be valid, msp, or dnf")
         return doc # __writeEventResultIndv_coc
+
+    def eventResultTeam(self):
+        return False

--- a/losttime/views/_output_template_coc.py
+++ b/losttime/views/_output_template_coc.py
@@ -11,10 +11,10 @@ from flask import flash
 
 
 class EventHtmlWriter_COC(EventHtmlWriter):
-    def __init__(self, event, style='generic', classes=None, results=None, teamclasses=None, teamresults=None, clubcodes=None):
-        super(EventHtmlWriter_COC, self).__init__(event, style, classes, results, teamclasses, teamresults, clubcodes)
+    def __init__(self, event, classes=None, results=None, teamclasses=None, teamresults=None, clubcodes=None):
+        super(EventHtmlWriter_COC, self).__init__(event, 'coc', classes, results, teamclasses, teamresults, clubcodes)
 
-    def __writeEventResultIndv(self):
+    def eventResultIndv(self):
         doc = div(cls="LostTimeContent", id="lt-top")
         with doc:
 

--- a/losttime/views/_output_template_coc.py
+++ b/losttime/views/_output_template_coc.py
@@ -1,0 +1,145 @@
+# losttime/views/_output_template_coc.py
+
+from _output_templates import EventHtmlWriter
+from _output_templates import _sortByPosition
+import datetime
+import pytz
+import csv, fileinput, sys
+import dominate
+from dominate.tags import *
+from flask import flash
+
+
+class EventHtmlWriter_COC(EventHtmlWriter):
+    def __init__(self, event, style='generic', classes=None, results=None, teamclasses=None, teamresults=None, clubcodes=None):
+        super(EventHtmlWriter_COC, self).__init__(event, style, classes, results, teamclasses, teamresults, clubcodes)
+
+    def __writeEventResultIndv(self):
+        doc = div(cls="LostTimeContent", id="lt-top")
+        with doc:
+
+            self.eventclasses.sort(key=lambda x: x.shortname)
+            WIOL = [x for x in self.eventclasses if x.shortname.startswith('W')]
+            if len(WIOL) > 0:
+                # Split Out Public and WIOL individual classes in menu
+                with div(cls="lg-mrg-bottom"):
+                    h2("Winter Series (Public)")
+                    for ec in self.eventclasses:
+                        if ec not in WIOL:
+                            h4(a(ec.name, href='#{0}'.format(ec.shortname)))
+                with div(cls="lg-mrg-bottom"):
+                    h2("WIOL School League - Individuals")
+                    for ec in WIOL:
+                        h4(a(ec.name, href='#{0}'.format(ec.shortname)))
+            else:
+                with div(cls="lg-mrg-bottom"):
+                    h2("Event Classes")
+                    for ec in self.eventclasses:
+                        h4(a(ec.name, href='#{0}'.format(ec.shortname)))
+
+            if len(self.teamclasses) > 0:
+                with div(cls="lg-mrg-bottom"):
+                    h2("WIOL School League - Teams")
+                    for tc in self.teamclasses:
+                        self.teamclasses.sort(key=lambda x: x.shortname)
+                        h4(a(tc.name, href='#{0}'.format(tc.shortname)))
+
+            for ec in self.eventclasses:
+                with div(cls="classResults lg-mrg-bottom"):
+                    classresults = [r for r in self.personresults if r.classid == ec.id]
+                    h3(ec.name, id=ec.shortname)
+                    t = table(cls="table table-striped", id='ResultsTable-{0}'.format(ec.shortname)).add(tbody())
+                    with t.add(tr(id="column-titles")):
+                        if ec.scoremethod in ['time', 'worldcup', '1000pts', 'score', 'score1000']:
+                            classresults = _sortByPosition(classresults)
+                            th('Pos.')
+                        th('Name')
+                        if ec in WIOL:
+                            th('School')
+                        else:
+                            th('Club')
+                        if ec.scoremethod in ['score', 'score1000']:
+                            th('Points')
+                            th('Penalty')
+                            th('Total')
+                        th('Time', cls="text-right")
+                        if ec.scoremethod in ['1000pts', 'worldcup', 'score1000']:
+                            th('Score', cls="text-right")
+                    for pr in classresults:
+                        with t.add(tr()):
+                            if ec.scoremethod in ['time', 'worldcup', '1000pts', 'score', 'score1000']:
+                                td(pr.position) if pr.position > 0 else td()
+                            td(pr.name)
+                            td(pr.club_shortname) if pr.club_shortname else td()
+                            if ec.scoremethod in ['score', 'score1000']:
+                                td(pr.ScoreO_points)
+                                td(pr.ScoreO_penalty)
+                                td(pr.ScoreO_net)
+                            if pr.coursestatus in ['ok']:
+                                td(pr.timetommmss(), cls="text-right")
+                            elif pr.resultstatus in ['ok']:
+                                td('{0} {1}'.format(pr.coursestatus, pr.timetommmss()), cls="text-right")
+                            elif pr.resultstatus in ['dns']:
+                                td('{0}'.format(pr.resultstatus), cls="text-right")
+                            else:
+                                td('{0} {1}*'.format(pr.resultstatus, pr.timetommmss()), cls="text-right")
+                            if (ec.scoremethod in ['worldcup', '1000pts', 'score1000']):
+                                td('{0:d}'.format(int(pr.score)), cls="text-right") if pr.score is not None else td()
+                p(a("Menu", href="#lt-top"), cls="lg-mrg-bottom text-center")
+            if len(self.teamclasses) > 0:
+                for tc in self.teamclasses:
+                    with div(cls="classResults lg-mrg-bottom"):
+                        classresults = [r for r in self.teamresults if r.teamclassid == tc.id]
+                        h3(tc.name, id=tc.shortname)
+                        t = table(cls='table table-striped', id='TeamResultsTable-{0}'.format(tc.shortname)).add(tbody())
+                        with t.add(tr(id='column-titles')):
+                            classresults = _sortByPosition(classresults)
+                            th('Place')
+                            th('Points')
+                            th('School / Name')
+                            th('Finish')
+                        for r in classresults:
+                            with t.add(tr(cls="team-result-full")):
+                                td(r.position) if r.position > 0 else td()
+                                td('{0:d}'.format(int(r.score))) if r.score is not None else td()
+                                try:
+                                    td('{0} ({1})'.format(self.clubcodes[r.teamname_short][0].name, r.teamname_short))
+                                except:
+                                    td(r.teamname_short)
+                                finpct = r.numfinishes if r.numfinishes == 0 else int((float(r.numfinishes)/r.numstarts)*100)
+                                td('{0}% ({1} of {2})'.format(finpct, r.numfinishes, r.numstarts))
+                            try:
+                                memberids = [int(x) for x in r.resultids.split(',')]
+                            except:
+                                memberids = []
+                            members = [x for x in self.personresults if x.id in memberids]
+                            members = _sortByPosition(members)
+                            for m in members:
+                                with t.add(tr(cls="team-result-member")):
+                                    td()
+                                    td('{0:d}'.format(int(m.score))) if m.score is not None else td()
+                                    td('{0} ({1})'.format(m.name, m.club_shortname))
+                                    if m.coursestatus in ['ok']:
+                                        td(m.timetommmss())
+                                    elif m.resultstatus in ['ok']:
+                                        td('{1} {0}'.format(m.timetommmss(), m.coursestatus))
+                                    else:
+                                        td('{1} {2} {0}'.format(m.timetommmss(), m.coursestatus, m.resultstatus))
+                    p(a("Menu", href="#lt-top"), cls="lg-mrg-bottom text-center")
+            h3("Result Status Codes")
+            with dl(cls="dl-horizontal"):
+                dt("msp: missing punch")
+                dd("a control was skipped or taken out of order")
+                dt("dnf: did not finish")
+                dd("a control or set of controls at the end of the course were skipped")
+                dt("nc: not competing")
+                dd("the competitor is not eligible for standings, such as when running a second course")
+                dt("dq: disqualified")
+                dd("breaking competition rules, such as conferring with another competitor or entering an out of bounds area")
+                dt("ovt: overtime")
+                dd("returning after the course closure time")
+                dt("dns: did not start")
+                dd("the competitor did not start")
+                dt("<time>*")
+                dd("the star indicates course completion status was not reported and may be valid, msp, or dnf")
+        return doc # __writeEventResultIndv_coc

--- a/losttime/views/_output_template_coc.py
+++ b/losttime/views/_output_template_coc.py
@@ -12,7 +12,7 @@ from flask import flash
 
 class EventHtmlWriter_COC(EventHtmlWriter):
     def __init__(self, event, classes=None, results=None, teamclasses=None, teamresults=None, clubcodes=None):
-        super(EventHtmlWriter_COC, self).__init__(event, 'coc', classes, results, teamclasses, teamresults, clubcodes)
+        super(EventHtmlWriter_COC, self).__init__(event, classes, results, teamclasses, teamresults, clubcodes)
 
     def eventResultIndv(self):
         doc = div(cls="LostTimeContent", id="lt-top")

--- a/losttime/views/_output_template_generic.py
+++ b/losttime/views/_output_template_generic.py
@@ -1,0 +1,80 @@
+# losttime/views/_output_template_generic.py
+
+from _output_templates import EventHtmlWriter
+from _output_templates import _sortByPosition
+import datetime
+import pytz
+import csv, fileinput, sys
+import dominate
+from dominate.tags import *
+from flask import flash
+
+
+class EventHtmlWriter_Generic(EventHtmlWriter):
+    def __init__(self, event, format='generic', classes=None, results=None, teamclasses=None, teamresults=None, clubcodes=None):
+        super(EventHtmlWriter_Generic, self).__init__(event, format, classes, results, teamclasses, teamresults, clubcodes)
+
+    def __writeEventResultIndv(self):
+        doc = dominate.document(title='Event Results')
+        with doc.head:
+            link(rel='stylesheet',
+                 href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css',
+                 integrity='sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7',
+                 crossorigin='anonymous')
+            link(rel='stylesheet',
+                 href='https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css')
+            meta(name='viewport', content='width=device-width, initial-scale=1.0')
+        with doc:
+            page = div(cls='container-fluid')
+        with page:
+            with div(cls='row').add(div(cls='col-xs-12')):
+                h1('Results for {0}'.format(self.event.name))
+                try:
+                    eventdate = datetime.date(*[int(x) for x in event.date.split('-')])
+                    p('An orienteering event held at {0} on {1:%d %B %Y}'.format(self.event.venue, eventdate))
+                except:
+                    pass
+                p('Competition Classes:')
+            with div(cls='row'):
+                for ec in self.eventclasses:
+                    self.eventclasses.sort(key=lambda x: x.shortname)
+                    div((a(ec.name, href='#{0}'.format(ec.shortname))), cls='col-md-3')
+            for ec in self.eventclasses:
+                with div(cls='row').add(div(cls='col-md-8')):
+                    classresults = [r for r in self.personresults if r.classid == ec.id]
+                    h3(ec.name, id=ec.shortname)
+                    t = table(cls='table table-striped table-condensed', id='ResultsTable-{0}'.format(ec.shortname))
+                    with t.add(tr(id='column-titles')):
+                        if ec.scoremethod in ['time', 'worldcup', '1000pts', 'score', 'score1000']:
+                            classresults = _sortByPosition(classresults)
+                            th('Pos.')
+                        th('Name')
+                        if ec.scoremethod in ['alpha']:
+                            classresults = _sortByName(classresults)
+                        th('Club')
+                        if ec.scoremethod in ['score', 'score1000']:
+                            th('Points')
+                            th('Penalty')
+                            th('Total')
+                        th('Time')
+                        if ec.scoremethod in ['1000pts', 'worldcup', 'score1000']:
+                            th('Score')
+                    for pr in classresults:
+                        with t.add(tr()):
+                            if ec.scoremethod in ['time', 'worldcup', '1000pts', 'score', 'score1000']:
+                                td(pr.position) if pr.position > 0 else td()
+                            td(pr.name)
+                            td(pr.club_shortname) if pr.club_shortname else td()
+                            if ec.scoremethod in ['score', 'score1000']:
+                                td(pr.ScoreO_points)
+                                td(pr.ScoreO_penalty)
+                                td(pr.ScoreO_net)
+                            if pr.coursestatus in ['ok']:
+                                td(pr.timetommmss())
+                            elif pr.resultstatus in ['ok']:
+                                td('{1} {0}'.format(pr.timetommmss(), pr.coursestatus))
+                            else:
+                                td('{1} {2} {0}'.format(pr.timetommmss(), pr.coursestatus, pr.resultstatus))
+                            if (ec.scoremethod in ['worldcup', '1000pts', 'score1000']):
+                                td('{0:d}'.format(int(pr.score))) if pr.score is not None else td()
+        return doc # __writeEventResultIndv

--- a/losttime/views/_output_template_generic.py
+++ b/losttime/views/_output_template_generic.py
@@ -12,7 +12,7 @@ from flask import flash
 
 class EventHtmlWriter_Generic(EventHtmlWriter):
     def __init__(self, event, classes=None, results=None, teamclasses=None, teamresults=None, clubcodes=None):
-        super(EventHtmlWriter_Generic, self).__init__(event, 'generic', classes, results, teamclasses, teamresults, clubcodes)
+        super(EventHtmlWriter_Generic, self).__init__(event, classes, results, teamclasses, teamresults, clubcodes)
 
     def eventResultIndv(self):
         doc = dominate.document(title='Event Results')

--- a/losttime/views/_output_template_generic.py
+++ b/losttime/views/_output_template_generic.py
@@ -78,3 +78,48 @@ class EventHtmlWriter_Generic(EventHtmlWriter):
                             if (ec.scoremethod in ['worldcup', '1000pts', 'score1000']):
                                 td('{0:d}'.format(int(pr.score))) if pr.score is not None else td()
         return doc # __writeEventResultIndv
+
+    def eventResultTeam(self):
+        doc = dominate.document(title='Event Results')
+        with doc.head:
+            link(rel='stylesheet',
+                 href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css',
+                 integrity='sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7',
+                 crossorigin='anonymous')
+            link(rel='stylsheet',
+                 href='https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css')
+            meta(name='viewport', content='width=device-width, initial-scale=1.0')
+        with doc:
+            page = div(cls='container-fluid')
+        with page:
+            with div(cls='row').add(div(cls='col-xs-12')):
+                h1('Team Results for {0}'.format(self.event.name))
+                try:
+                    eventdate = datetime.date(*[int(x) for x in self.event.date.split('-')])
+                    p('An orienteering event held at {0} on {1:%d %B %Y}'.format(self.event.venue, eventdate))
+                except:
+                    pass
+                p('Team Competition Classes:')
+            with div(cls='row'):
+                for tc in self.teamclasses:
+                    self.teamclasses.sort(key=lambda x: x.shortname)
+                    div((a(tc.name, href='#{0}'.format(tc.shortname))), cls='col-md-3')
+            for tc in self.teamclasses:
+                with div(cls='row').add(div(cls='col-md-8')):
+                    classresults = [r for r in self.teamresults if r.teamclassid == tc.id]
+                    h3(tc.name, id=tc.shortname)
+                    t = table(cls='table table-striped table-condensed',
+                              id='TeamResultsTable-{0}'.format(tc.shortname))
+                    with t.add(tr(id='column-titles')):
+                        classresults = _sortByPosition(classresults)
+                        th('Pos.')
+                        th('Name')
+                        th('Score')
+                    for r in classresults:
+                        with t.add(tr()):
+                            td(r.position) if r.position > 0 else td()
+                            td(r.teamname_short)
+                            td('{0:d}'.format(int(r.score))) if r.score is not None else td()
+        return doc  # __writeEventResultTeam
+
+

--- a/losttime/views/_output_template_generic.py
+++ b/losttime/views/_output_template_generic.py
@@ -11,10 +11,10 @@ from flask import flash
 
 
 class EventHtmlWriter_Generic(EventHtmlWriter):
-    def __init__(self, event, format='generic', classes=None, results=None, teamclasses=None, teamresults=None, clubcodes=None):
-        super(EventHtmlWriter_Generic, self).__init__(event, format, classes, results, teamclasses, teamresults, clubcodes)
+    def __init__(self, event, classes=None, results=None, teamclasses=None, teamresults=None, clubcodes=None):
+        super(EventHtmlWriter_Generic, self).__init__(event, 'generic', classes, results, teamclasses, teamresults, clubcodes)
 
-    def __writeEventResultIndv(self):
+    def eventResultIndv(self):
         doc = dominate.document(title='Event Results')
         with doc.head:
             link(rel='stylesheet',

--- a/losttime/views/_output_templates.py
+++ b/losttime/views/_output_templates.py
@@ -12,9 +12,8 @@ from flask import flash
 class EventHtmlWriter(object):
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, event, format='generic', classes=None, results=None, teamclasses=None, teamresults=None, clubcodes=None):
+    def __init__(self, event, classes=None, results=None, teamclasses=None, teamresults=None, clubcodes=None):
         self.event = event
-        self.format = format
         self.eventclasses = classes
         self.personresults = results
         self.teamclasses = teamclasses

--- a/losttime/views/_output_templates.py
+++ b/losttime/views/_output_templates.py
@@ -38,60 +38,21 @@ class EventHtmlWriter(object):
     #     else:
     #         raise KeyError("Unrecognized output format {0}".format(self.format))
 
+    @abc.abstractmethod
     def eventResultTeam(self):
         """
         create an html file with team results for this event
         """
-        if len(self.teamclasses) == 0:
-            return False
-        if self.format == 'generic':
-            return self.__writeEventResultTeam()
-        elif self.format == 'coc':
-            return False #team results included on indv result page
-        else:
-            raise KeyError("Unrecognized output format {0}".format(self.format))
+        pass
+        # if len(self.teamclasses) == 0:
+        #     return False
+        # if self.format == 'generic':
+        #     return self.__writeEventResultTeam()
+        # elif self.format == 'coc':
+        #     return False #team results included on indv result page
+        # else:
+        #     raise KeyError("Unrecognized output format {0}".format(self.format))
 
-    def __writeEventResultTeam(self):
-        doc = dominate.document(title='Event Results')
-        with doc.head:
-            link(rel='stylesheet',
-                 href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css',
-                 integrity='sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7',
-                 crossorigin='anonymous')
-            link(rel='stylsheet',
-                 href='https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css')
-            meta(name='viewport', content='width=device-width, initial-scale=1.0')
-        with doc:
-            page = div(cls='container-fluid')
-        with page:
-            with div(cls='row').add(div(cls='col-xs-12')):
-                h1('Team Results for {0}'.format(self.event.name))
-                try:
-                    eventdate = datetime.date(*[int(x) for x in self.event.date.split('-')])
-                    p('An orienteering event held at {0} on {1:%d %B %Y}'.format(self.event.venue, eventdate))
-                except:
-                    pass
-                p('Team Competition Classes:')
-            with div(cls='row'):
-                for tc in self.teamclasses:
-                    self.teamclasses.sort(key=lambda x: x.shortname)
-                    div((a(tc.name, href='#{0}'.format(tc.shortname))), cls='col-md-3')
-            for tc in self.teamclasses:
-                with div(cls='row').add(div(cls='col-md-8')):
-                    classresults = [r for r in self.teamresults if r.teamclassid == tc.id]
-                    h3(tc.name, id=tc.shortname)
-                    t = table(cls='table table-striped table-condensed', id='TeamResultsTable-{0}'.format(tc.shortname))
-                    with t.add(tr(id='column-titles')):
-                        classresults = _sortByPosition(classresults)
-                        th('Pos.')
-                        th('Name')
-                        th('Score')
-                    for r in classresults:
-                        with t.add(tr()):
-                            td(r.position) if r.position > 0 else td()
-                            td(r.teamname_short)
-                            td('{0:d}'.format(int(r.score))) if r.score is not None else td()
-        return doc # __writeEventResultTeam
 
 
 class SeriesHtmlWriter(object):

--- a/losttime/views/_output_templates.py
+++ b/losttime/views/_output_templates.py
@@ -4,11 +4,14 @@ import datetime
 import pytz
 import csv, fileinput, sys
 import dominate
+import abc
 from dominate.tags import *
 from flask import flash
 
 
 class EventHtmlWriter(object):
+    __metaclass__ = abc.ABCMeta
+
     def __init__(self, event, format='generic', classes=None, results=None, teamclasses=None, teamresults=None, clubcodes=None):
         self.event = event
         self.format = format
@@ -18,16 +21,22 @@ class EventHtmlWriter(object):
         self.teamresults = teamresults
         self.clubcodes = clubcodes
 
+    @abc.abstractmethod
     def eventResultIndv(self):
         """
-        create an html file with individual, or individual+team results for this event.
+
+        :return:
         """
-        if self.format == 'generic':
-            return self.__writeEventResultIndv()
-        elif self.format == 'coc':
-            return self.__writeEventResultIndv_coc()
-        else:
-            raise KeyError("Unrecognized output format {0}".format(self.format))
+        pass
+    #     """
+    #     create an html file with individual, or individual+team results for this event.
+    #     """
+    #     if self.format == 'generic':
+    #         return self.__writeEventResultIndv()
+    #     elif self.format == 'coc':
+    #         return self.__writeEventResultIndv_coc()
+    #     else:
+    #         raise KeyError("Unrecognized output format {0}".format(self.format))
 
     def eventResultTeam(self):
         """

--- a/losttime/views/_output_templates.py
+++ b/losttime/views/_output_templates.py
@@ -7,6 +7,7 @@ import dominate
 from dominate.tags import *
 from flask import flash
 
+
 class EventHtmlWriter(object):
     def __init__(self, event, format='generic', classes=None, results=None, teamclasses=None, teamresults=None, clubcodes=None):
         self.event = event
@@ -40,203 +41,6 @@ class EventHtmlWriter(object):
             return False #team results included on indv result page
         else:
             raise KeyError("Unrecognized output format {0}".format(self.format))
-
-
-    def __writeEventResultIndv(self):
-        doc = dominate.document(title='Event Results')
-        with doc.head:
-            link(rel='stylesheet',
-                 href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css',
-                 integrity='sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7',
-                 crossorigin='anonymous')
-            link(rel='stylesheet',
-                 href='https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css')
-            meta(name='viewport', content='width=device-width, initial-scale=1.0')
-        with doc:
-            page = div(cls='container-fluid')
-        with page:
-            with div(cls='row').add(div(cls='col-xs-12')):
-                h1('Results for {0}'.format(self.event.name))
-                try:
-                    eventdate = datetime.date(*[int(x) for x in event.date.split('-')])
-                    p('An orienteering event held at {0} on {1:%d %B %Y}'.format(self.event.venue, eventdate))
-                except:
-                    pass
-                p('Competition Classes:')
-            with div(cls='row'):
-                for ec in self.eventclasses:
-                    self.eventclasses.sort(key=lambda x: x.shortname)
-                    div((a(ec.name, href='#{0}'.format(ec.shortname))), cls='col-md-3')
-            for ec in self.eventclasses:
-                with div(cls='row').add(div(cls='col-md-8')):
-                    classresults = [r for r in self.personresults if r.classid == ec.id]
-                    h3(ec.name, id=ec.shortname)
-                    t = table(cls='table table-striped table-condensed', id='ResultsTable-{0}'.format(ec.shortname))
-                    with t.add(tr(id='column-titles')):
-                        if ec.scoremethod in ['time', 'worldcup', '1000pts', 'score', 'score1000']:
-                            classresults = _sortByPosition(classresults)
-                            th('Pos.')
-                        th('Name')
-                        if ec.scoremethod in ['alpha']:
-                            classresults = _sortByName(classresults)
-                        th('Club')
-                        if ec.scoremethod in ['score', 'score1000']:
-                            th('Points')
-                            th('Penalty')
-                            th('Total')
-                        th('Time')
-                        if ec.scoremethod in ['1000pts', 'worldcup', 'score1000']:
-                            th('Score')
-                    for pr in classresults:
-                        with t.add(tr()):
-                            if ec.scoremethod in ['time', 'worldcup', '1000pts', 'score', 'score1000']:
-                                td(pr.position) if pr.position > 0 else td()
-                            td(pr.name)
-                            td(pr.club_shortname) if pr.club_shortname else td()
-                            if ec.scoremethod in ['score', 'score1000']:
-                                td(pr.ScoreO_points)
-                                td(pr.ScoreO_penalty)
-                                td(pr.ScoreO_net)
-                            if pr.coursestatus in ['ok']:
-                                td(pr.timetommmss())
-                            elif pr.resultstatus in ['ok']:
-                                td('{1} {0}'.format(pr.timetommmss(), pr.coursestatus))
-                            else:
-                                td('{1} {2} {0}'.format(pr.timetommmss(), pr.coursestatus, pr.resultstatus))
-                            if (ec.scoremethod in ['worldcup', '1000pts', 'score1000']):
-                                td('{0:d}'.format(int(pr.score))) if pr.score is not None else td()
-        return doc # __writeEventResultIndv
-
-    def __writeEventResultIndv_coc(self):
-        doc = div(cls="LostTimeContent", id="lt-top")
-        with doc:
-
-            self.eventclasses.sort(key=lambda x: x.shortname)
-            WIOL = [x for x in self.eventclasses if x.shortname.startswith('W')]
-            if len(WIOL) > 0:
-                # Split Out Public and WIOL individual classes in menu
-                with div(cls="lg-mrg-bottom"):
-                    h2("Winter Series (Public)")
-                    for ec in self.eventclasses:
-                        if ec not in WIOL:
-                            h4(a(ec.name, href='#{0}'.format(ec.shortname)))
-                with div(cls="lg-mrg-bottom"):
-                    h2("WIOL School League - Individuals")
-                    for ec in WIOL:
-                        h4(a(ec.name, href='#{0}'.format(ec.shortname)))
-            else:
-                with div(cls="lg-mrg-bottom"):
-                    h2("Event Classes")
-                    for ec in self.eventclasses:
-                        h4(a(ec.name, href='#{0}'.format(ec.shortname)))
-
-            if len(self.teamclasses) > 0:
-                with div(cls="lg-mrg-bottom"):
-                    h2("WIOL School League - Teams")
-                    for tc in self.teamclasses:
-                        self.teamclasses.sort(key=lambda x: x.shortname)
-                        h4(a(tc.name, href='#{0}'.format(tc.shortname)))
-
-            for ec in self.eventclasses:
-                with div(cls="classResults lg-mrg-bottom"):
-                    classresults = [r for r in self.personresults if r.classid == ec.id]
-                    h3(ec.name, id=ec.shortname)
-                    t = table(cls="table table-striped", id='ResultsTable-{0}'.format(ec.shortname)).add(tbody())
-                    with t.add(tr(id="column-titles")):
-                        if ec.scoremethod in ['time', 'worldcup', '1000pts', 'score', 'score1000']:
-                            classresults = _sortByPosition(classresults)
-                            th('Pos.')
-                        th('Name')
-                        if ec in WIOL:
-                            th('School')
-                        else:
-                            th('Club')
-                        if ec.scoremethod in ['score', 'score1000']:
-                            th('Points')
-                            th('Penalty')
-                            th('Total')
-                        th('Time', cls="text-right")
-                        if ec.scoremethod in ['1000pts', 'worldcup', 'score1000']:
-                            th('Score', cls="text-right")
-                    for pr in classresults:
-                        with t.add(tr()):
-                            if ec.scoremethod in ['time', 'worldcup', '1000pts', 'score', 'score1000']:
-                                td(pr.position) if pr.position > 0 else td()
-                            td(pr.name)
-                            td(pr.club_shortname) if pr.club_shortname else td()
-                            if ec.scoremethod in ['score', 'score1000']:
-                                td(pr.ScoreO_points)
-                                td(pr.ScoreO_penalty)
-                                td(pr.ScoreO_net)
-                            if pr.coursestatus in ['ok']:
-                                td(pr.timetommmss(), cls="text-right")
-                            elif pr.resultstatus in ['ok']:
-                                td('{0} {1}'.format(pr.coursestatus, pr.timetommmss()), cls="text-right")
-                            elif pr.resultstatus in ['dns']:
-                                td('{0}'.format(pr.resultstatus), cls="text-right")
-                            else:
-                                td('{0} {1}*'.format(pr.resultstatus, pr.timetommmss()), cls="text-right")
-                            if (ec.scoremethod in ['worldcup', '1000pts', 'score1000']):
-                                td('{0:d}'.format(int(pr.score)), cls="text-right") if pr.score is not None else td()
-                p(a("Menu", href="#lt-top"), cls="lg-mrg-bottom text-center")
-            if len(self.teamclasses) > 0:
-                for tc in self.teamclasses:
-                    with div(cls="classResults lg-mrg-bottom"):
-                        classresults = [r for r in self.teamresults if r.teamclassid == tc.id]
-                        h3(tc.name, id=tc.shortname)
-                        t = table(cls='table table-striped', id='TeamResultsTable-{0}'.format(tc.shortname)).add(tbody())
-                        with t.add(tr(id='column-titles')):
-                            classresults = _sortByPosition(classresults)
-                            th('Place')
-                            th('Points')
-                            th('School / Name')
-                            th('Finish')
-                        for r in classresults:
-                            with t.add(tr(cls="team-result-full")):
-                                td(r.position) if r.position > 0 else td()
-                                td('{0:d}'.format(int(r.score))) if r.score is not None else td()
-                                try:
-                                    td('{0} ({1})'.format(self.clubcodes[r.teamname_short][0].name, r.teamname_short))
-                                except:
-                                    td(r.teamname_short)
-                                finpct = r.numfinishes if r.numfinishes == 0 else int((float(r.numfinishes)/r.numstarts)*100)
-                                td('{0}% ({1} of {2})'.format(finpct, r.numfinishes, r.numstarts))
-                            try:
-                                memberids = [int(x) for x in r.resultids.split(',')]
-                            except:
-                                memberids = []
-                            members = [x for x in self.personresults if x.id in memberids]
-                            members = _sortByPosition(members)
-                            for m in members:
-                                with t.add(tr(cls="team-result-member")):
-                                    td()
-                                    td('{0:d}'.format(int(m.score))) if m.score is not None else td()
-                                    td('{0} ({1})'.format(m.name, m.club_shortname))
-                                    if m.coursestatus in ['ok']:
-                                        td(m.timetommmss())
-                                    elif m.resultstatus in ['ok']:
-                                        td('{1} {0}'.format(m.timetommmss(), m.coursestatus))
-                                    else:
-                                        td('{1} {2} {0}'.format(m.timetommmss(), m.coursestatus, m.resultstatus))
-                    p(a("Menu", href="#lt-top"), cls="lg-mrg-bottom text-center")
-            h3("Result Status Codes")
-            with dl(cls="dl-horizontal"):
-                dt("msp: missing punch")
-                dd("a control was skipped or taken out of order")
-                dt("dnf: did not finish")
-                dd("a control or set of controls at the end of the course were skipped")
-                dt("nc: not competing")
-                dd("the competitor is not eligible for standings, such as when running a second course")
-                dt("dq: disqualified")
-                dd("breaking competition rules, such as conferring with another competitor or entering an out of bounds area")
-                dt("ovt: overtime")
-                dd("returning after the course closure time")
-                dt("dns: did not start")
-                dd("the competitor did not start")
-                dt("<time>*")
-                dd("the star indicates course completion status was not reported and may be valid, msp, or dnf")
-        return doc # __writeEventResultIndv_coc
-
 
     def __writeEventResultTeam(self):
         doc = dominate.document(title='Event Results')
@@ -361,7 +165,6 @@ class SeriesHtmlWriter(object):
 
                             td(int(r['score']))
         return doc
-
 
 
 class EntryWriter(object):
@@ -594,6 +397,7 @@ class EntryWriter(object):
                 continue
         return datacols
 
+
 def _sortByPosition(results):
     """
     Sort by position, with position -1 at the end.
@@ -608,9 +412,11 @@ def _sortByPosition(results):
     valid.sort(key=lambda x: x.position)
     return valid + invalid
 
+
 def _sortByName(results):
     results = sorted(results, key=lambda x: x.name)
     return results
+
 
 def _nextbib(initial=1001):
     i = initial

--- a/losttime/views/event_result.py
+++ b/losttime/views/event_result.py
@@ -7,6 +7,8 @@ from losttime import eventfiles
 from losttime.models import db, Event, EventClass, PersonResult, EventTeamClass, TeamResult, ClubCode
 from _orienteer_data import OrienteerResultReader
 from _output_templates import EventHtmlWriter
+from _output_template_coc import EventHtmlWriter_COC
+from _output_template_generic import EventHtmlWriter_Generic
 from os import remove
 from os.path import join
 
@@ -510,10 +512,20 @@ def _buildResultPages(eventid, style):
     for club in ClubCode.query.all():
         clubcodes.setdefault(club.code, []).append(club)
 
-    writer = EventHtmlWriter(event, style, classes, results, teamclasses, teamresults, clubcodes)
+    writer = EventHtmlWriterHandler(event, style, classes, results, teamclasses, teamresults, clubcodes)
     docdict = {}
     docdict['indv'] = writer.eventResultIndv()
     teamdoc = writer.eventResultTeam()
     if teamdoc: # false if no team results page
         docdict['team'] = teamdoc
     return docdict
+
+
+def EventHtmlWriterHandler(event, style='generic', classes=None, results=None, teamclasses=None, teamresults=None,
+                           clubcodes=None):
+    if style == 'coc':
+        return EventHtmlWriter_COC(event, style, classes, results, teamclasses, teamresults, clubcodes)
+    else:
+        return EventHtmlWriter_Generic(event, style, classes, results, teamclasses, teamresults, clubcodes)
+
+

--- a/losttime/views/event_result.py
+++ b/losttime/views/event_result.py
@@ -520,12 +520,18 @@ def _buildResultPages(eventid, style):
         docdict['team'] = teamdoc
     return docdict
 
+handlers = {
+    'coc': EventHtmlWriter_COC,
+    'generic': EventHtmlWriter_Generic,
+}
+
 
 def EventHtmlWriterHandler(event, style='generic', classes=None, results=None, teamclasses=None, teamresults=None,
                            clubcodes=None):
-    if style == 'coc':
-        return EventHtmlWriter_COC(event, classes, results, teamclasses, teamresults, clubcodes)
-    else:
-        return EventHtmlWriter_Generic(event, classes, results, teamclasses, teamresults, clubcodes)
+    return handlers[style](event, classes, results, teamclasses, teamresults, clubcodes)
+    # if style == 'coc':
+    #     return EventHtmlWriter_COC(event, classes, results, teamclasses, teamresults, clubcodes)
+    # else:
+    #     return EventHtmlWriter_Generic(event, classes, results, teamclasses, teamresults, clubcodes)
 
 

--- a/losttime/views/event_result.py
+++ b/losttime/views/event_result.py
@@ -524,8 +524,8 @@ def _buildResultPages(eventid, style):
 def EventHtmlWriterHandler(event, style='generic', classes=None, results=None, teamclasses=None, teamresults=None,
                            clubcodes=None):
     if style == 'coc':
-        return EventHtmlWriter_COC(event, style, classes, results, teamclasses, teamresults, clubcodes)
+        return EventHtmlWriter_COC(event, classes, results, teamclasses, teamresults, clubcodes)
     else:
-        return EventHtmlWriter_Generic(event, style, classes, results, teamclasses, teamresults, clubcodes)
+        return EventHtmlWriter_Generic(event, classes, results, teamclasses, teamresults, clubcodes)
 
 

--- a/losttime/views/event_result.py
+++ b/losttime/views/event_result.py
@@ -520,7 +520,8 @@ def _buildResultPages(eventid, style):
         docdict['team'] = teamdoc
     return docdict
 
-handlers = {
+
+htmlWriterHandlers = {
     'coc': EventHtmlWriter_COC,
     'generic': EventHtmlWriter_Generic,
 }
@@ -528,7 +529,7 @@ handlers = {
 
 def EventHtmlWriterHandler(event, style='generic', classes=None, results=None, teamclasses=None, teamresults=None,
                            clubcodes=None):
-    return handlers[style](event, classes, results, teamclasses, teamresults, clubcodes)
+    return htmlWriterHandlers[style](event, classes, results, teamclasses, teamresults, clubcodes)
     # if style == 'coc':
     #     return EventHtmlWriter_COC(event, classes, results, teamclasses, teamresults, clubcodes)
     # else:

--- a/losttime/views/test_eventHtmlWriter_COC.py
+++ b/losttime/views/test_eventHtmlWriter_COC.py
@@ -1,0 +1,10 @@
+from unittest import TestCase
+
+from losttime.views._output_template_coc import EventHtmlWriter_COC
+
+
+class TestEventHtmlWriter_COC(TestCase):
+    def test_eventResultTeam(self):
+        writer = EventHtmlWriter_COC('testevent')
+        self.assertFalse(writer.eventResultTeam())
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,8 @@ fuzzywuzzy==0.15.0
 gunicorn==19.6.0
 html5lib==0.999999999
 itsdangerous==0.24
-lxml==3.6.4
+#lxml==3.6.4
+lxml==4.2.1
 pycparser==2.18
 python-Levenshtein==0.12.0
 python-editor==1.0.1


### PR DESCRIPTION
(fixed something I forgot to put in)

Refactoring the output templates - includes a lookup to automatically pass output writer object based on results style (htmlWriterHandlers).

I also updated lxml to 4.2.1 - let me know if that's something you don't want to do.